### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/alrazauk80/cfb6b53d-54fd-4732-9a04-1964a5295b59/d24c5289-6a5e-4f6d-8a52-a0c00a216524/_apis/work/boardbadge/a8f2f7a0-03b2-4102-b4d3-d66eb1c5dac1)](https://dev.azure.com/alrazauk80/cfb6b53d-54fd-4732-9a04-1964a5295b59/_boards/board/t/d24c5289-6a5e-4f6d-8a52-a0c00a216524/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#9](https://dev.azure.com/alrazauk80/cfb6b53d-54fd-4732-9a04-1964a5295b59/_workitems/edit/9). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.